### PR TITLE
Fix w3c.json syntax.

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
-    "group":      ["80485"]
+    "group":      80485
 ,   "contacts":   ["yoavweiss"]
-,   "repo-type":  cg-report
+,   "repo-type":  "cg-report"
 }


### PR DESCRIPTION
Per https://w3c.github.io/w3c.json.html, the group value should be a number or array of numbers, and the repo-type value should be a quoted string.