### PR TITLE
Explicitly add event handler content attributes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -420,6 +420,9 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
     </tbody>
   </table>
 
+  The <{portal}> element exposes {{HTMLPortalElement/onmessage}} and {{HTMLPortalElement/onmessageerror}}
+  as [=event handler content attributes=].
+
   The `PortalHost` interface {#the-portalhost-interface}
   ------------------------------------------------------
 
@@ -574,6 +577,10 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
       </tr>
     </tbody>
   </table>
+
+  Like other [=event handler IDL attributes=] in the {{WindowEventHandlers}} interface mixin,
+  {{WindowEventHandlers/onportalactivate}} is exposed on all <{body}> and <{frameset}> elements
+  as a [=event handler content attribute=].
 </section>
 
 <section>


### PR DESCRIPTION
Technically parsing onmessage etc from DOM attributes is a separate thing from doing so as an IDL attribute and requires being explicitly specified. Adding this to be consistent with other events.