### PR TITLE
Clear the guest browsing context of a <portal> during activate.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -265,6 +265,14 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
         |options|["{{PortalActivateOptions/transfer}}"]).
         Rethrow any exceptions.
 
+    1. Clear the [=guest browsing context=] of the [=context object=].
+        User agents *should*, however, attempt to preserve the rendering of the
+        guest browsing context until |predecessorBrowsingContext| has been replaced
+        with |portalBrowsingContext| in the rendering.
+
+        Note: This is intended to avoid a visual glitch, such as a "white flash", where
+        the guest browsing context briefly disappears.
+
     1. Let |promise| be a new [=promise=].
 
     1. Run the steps to [=activate a portal browsing context|activate=] |portalBrowsingContext|


### PR DESCRIPTION
I couldn't think of a way to explicitly capture the state where the UA tries to render while portal has lost its guest browsing context but before swapping, so I ended up just going for wording that UAs should do what they can to avoid this (the Chromium compositing path seems to make this possible, but it's hard to know what would be required in other UAs, especially since the timing of this sort of thing doesn't seem to be speced in detail).