### PR TITLE
Remove use of 'context object' from dom.spec.whatwg.org.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -239,7 +239,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   <section algorithm="htmlportalelement-activate">
     The <dfn method for="HTMLPortalElement"><code>activate(|options|)</code></dfn> method *must* run these steps:
 
-    1. Let |portalBrowsingContext| be the [=guest browsing context=] of the [=context object=].
+    1. Let |portalBrowsingContext| be the [=guest browsing context=] of [=this=].
 
         If no such context exists, throw an "{{InvalidStateError}}" {{DOMException}}.
 
@@ -247,8 +247,8 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
           portals-activate-no-browsing-context.html
         </wpt>
 
-    1. Let |predecessorBrowsingContext| be the [=document browsing context|browsing context=] of the
-        [=context object=]'s [=node document|document=].
+    1. Let |predecessorBrowsingContext| be the [=document browsing context|browsing context=] of
+        [=this=]'s [=node document|document=].
 
         If no such context exists, throw an "{{InvalidStateError}}" {{DOMException}}.
 
@@ -263,7 +263,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
         |options|["{{PortalActivateOptions/transfer}}"]).
         Rethrow any exceptions.
 
-    1. Clear the [=guest browsing context=] of the [=context object=].
+    1. Clear the [=guest browsing context=] of [=this=].
         User agents *should*, however, attempt to preserve the rendering of the
         guest browsing context until |predecessorBrowsingContext| has been replaced
         with |portalBrowsingContext| in the rendering.
@@ -299,11 +299,11 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
     The <dfn method for="HTMLPortalElement"><code>postMessage(|message|, |options|)</code></dfn> method *must* run these steps:
 
-    1. Let |portalBrowsingContext| be the [=guest browsing context=] of the [=context object=].
+    1. Let |portalBrowsingContext| be the [=guest browsing context=] of [=this=].
 
         If no such context exists, throw an "{{InvalidStateError}}" {{DOMException}}.
 
-    1. Let |settings| be the [=relevant settings object=] of the [=context object=].
+    1. Let |settings| be the [=relevant settings object=] of [=this=].
 
     1. Let |origin| be the [=serialization of an origin|serialization=] of |settings|'s [=environment settings object/origin=].
 
@@ -350,19 +350,19 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   </section>
 
   <section algorithm="htmlportalelement-acceptpostedmessage">
-    To [=accept a message posted to the host=] for a <{portal}> element with
+    To [=accept a message posted to the host=] for a <{portal}> element |element| with
     |serializeWithTransferResult|, |browsingContext|, |origin| and |targetOrigin|,
     [=queue a task=] from the [=portal task source=] to the [=event loop=] associated with
     the element's [=node document|document=]'s [=document browsing context|browsing context=]
     to run the following steps:
 
-    1. If |browsingContext| is not the [=guest browsing context=] of the [=context object], then abort these steps.
+    1. If |browsingContext| is not the [=guest browsing context=] of |element|, then abort these steps.
 
         Note: This might happen if this [=event loop=] had a queued task to deliver a message, but
         it was not executed before the portal was [=activate a portal browsing context|activated=].
         In such cases, the message is not delivered.
 
-    1. Let |settings| be the [=relevant settings object=] of the [=context object=].
+    1. Let |settings| be the [=relevant settings object=] of |element|.
 
     1. If |targetOrigin| is not a single literal U+002A ASTERISK character
         (*) and |settings|'s [=environment settings object/origin=] is not
@@ -372,38 +372,38 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
     1. Let |deserializeRecord| be [$StructuredDeserializeWithTransfer$](|serializeWithTransferResult|, |targetRealm|).
 
-        If this throws an exception, catch it, [=fire an event=] named {{HTMLPortalElement/messageerror!!event}} at the [=context object=] using {{MessageEvent}}
-        with the {{MessageEvent/origin}} attribute initialized to |origin| and the {{MessageEvent/source}} attribute initialized to the [=context object=],
+        If this throws an exception, catch it, [=fire an event=] named {{HTMLPortalElement/messageerror!!event}} at |element| using {{MessageEvent}}
+        with the {{MessageEvent/origin}} attribute initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |element|.
 
     1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
 
     1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in
         |deserializeRecord|.\[[TransferredValues]], if any, maintaining their relative order.
 
-    1. [=Fire an event=] named {{HTMLPortalElement/message!!event}} at the [=context object=] using {{MessageEvent}}, with the {{MessageEvent/origin}} attribute
-        initialized to |origin|, the {{MessageEvent/source}} attribute initialized to the [=context object=], the {{MessageEvent/data}} attribute
+    1. [=Fire an event=] named {{HTMLPortalElement/message!!event}} at the |element| using {{MessageEvent}}, with the {{MessageEvent/origin}} attribute
+        initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |element|, the {{MessageEvent/data}} attribute
         initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
   </section>
 
   <section algorithm="htmlportalelement-close">
-    To <dfn for="HTMLPortalElement">close a <{portal}> element</dfn>, run the following steps:
+    To <dfn for="HTMLPortalElement">close a <{portal}> element</dfn> |element|, run the following steps:
 
-    1. If the [=context object=] has a [=guest browsing context=], then [=close a browsing context|close=] it.
+    1. If |element| has a [=guest browsing context=], then [=close a browsing context|close=] it.
         The user agent *should not* [=refuse to allow the document to be unloaded=].
 
-    1. Clear the [=context object=]'s [=guest browsing context=].
+    1. Clear |element|'s [=guest browsing context=].
   </section>
 
   <section algorithm="htmlportalelement-setsourceurl">
-    To <dfn for="HTMLPortalElement">set the source URL of a <{portal}> element</dfn>, run the following steps:
+    To <dfn for="HTMLPortalElement">set the source URL of a <{portal}> element</dfn> |element|, run the following steps:
 
-    1. [=Assert=]: The [=context object=] has a [=guest browsing context=].
+    1. [=Assert=]: |element| has a [=guest browsing context=].
 
-    1. If the [=context object=] has no {{HTMLPortalElement/src}} attribute specified, or its value is the empty string,
-        then [=close a portal element|close=] the [=context object=] and abort these steps.
+    1. If |element| has no {{HTMLPortalElement/src}} attribute specified, or its value is the empty string,
+        then [=close a portal element|close=] |element| and abort these steps.
 
     1. [=Parse a URL|Parse=] the value of the {{HTMLPortalElement/src}} attribute. If that is not successful,
-        then [=close a portal element|close=] the [=context object=] and abort these steps.
+        then [=close a portal element|close=] |element| and abort these steps.
         Otherwise, let |url| be the [=resulting URL record=].
 
     1. Let |resource| be a new [=request=] whose [=request URL|URL=] is |url| and whose [=request referrer policy|referrer policy=] is "{{no-referrer}}".
@@ -420,17 +420,17 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
     portals-no-referrer.html
   </wpt>
 
-  Whenever a <{portal}> element's {{HTMLPortalElement/src}} attribute is set, run the following steps:
+  Whenever a <{portal}> element |element|'s {{HTMLPortalElement/src}} attribute is set, run the following steps:
 
-  1. If the [=context object=] does not have a [=guest browsing context=], abort these steps.
+  1. If |element| does not have a [=guest browsing context=], abort these steps.
 
-  1. [=set the source URL of a portal element|Set the source URL=] of the [=context object=].
+  1. [=set the source URL of a portal element|Set the source URL=] of |element|.
 
-  Whenever a <{portal}> element is [=insertion steps|inserted=], run the following steps:
+  Whenever a <{portal}> element |element| is [=insertion steps|inserted=], run the following steps:
 
-  1. If the [=context object=] has a [=guest browsing context=] or is not [=connected=], abort these steps.
+  1. If |element| has a [=guest browsing context=] or is not [=connected=], abort these steps.
 
-  1. If the the [=document browsing context|browsing context=] of the [=context object=]'s [=node document|document=]
+  1. If the the [=document browsing context|browsing context=] of |element|'s [=node document|document=]
       is a nested browsing context or there is no such context, then abort these steps.
 
       <p class="note">
@@ -442,22 +442,22 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   1. [=Create a new browsing context=] with noopener, and let |newBrowsingContext| be the result.
 
   1. Set the [=portal state=] of |newBrowsingContext| to *portal*, and set the [=host=] of
-      |newBrowsingContext| to the [=context object=].
+      |newBrowsingContext| to |element|.
 
-  1. Set the [=context object=]'s [=guest browsing context=] to |newBrowsingContext|.
+  1. Set |element|'s [=guest browsing context=] to |newBrowsingContext|.
 
-  1. [=set the source URL of a portal element|Set the source URL=] of the [=context object=].
+  1. [=set the source URL of a portal element|Set the source URL=] of |element|.
 
   <wpt>
     portals-create-orphaned.html
     portals-nested.html
   </wpt>
 
-  Whenever a <{portal}> element is [=removing steps|removed=], run the following steps:
+  Whenever a <{portal}> element |element| is [=removing steps|removed=], run the following steps:
 
-  1. If the [=context object=] does not have a [=guest browsing context=], abort these steps.
+  1. If |element| does not have a [=guest browsing context=], abort these steps.
 
-  1. [=close a portal element|Close=] the [=context object=].
+  1. [=close a portal element|Close=] |element|.
 
   <div class="issue">
     It might be convenient to not immediately detach the portal element, but instead to do so
@@ -465,11 +465,11 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
     its browsing context.
   </div>
 
-  Whenever a <{portal}> element is [=adopting steps|adopted=], run the following steps:
+  Whenever a <{portal}> element |element| is [=adopting steps|adopted=], run the following steps:
 
-  1. If the [=context object=] does not have a [=guest browsing context=], abort these steps.
+  1. If |element| does not have a [=guest browsing context=], abort these steps.
 
-  1. [=close a portal element|Close=] the [=context object=].
+  1. [=close a portal element|Close=] |element|.
 
   <div class="note">
     Since <{portal}> elements can have only a [=guest browsing context=] while
@@ -536,7 +536,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
     The <dfn method for="PortalHost"><code>postMessage(|message|, |options|)</code></dfn> method *must* run these steps:
 
-    1. Let |settings| be the [=relevant settings object=] of the [=context object=].
+    1. Let |settings| be the [=relevant settings object=] of [=this=].
 
     1. Let |browsingContext| be the [=responsible browsing context=] of |settings|.
 
@@ -557,7 +557,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
     1. Let |serializeWithTransferResult| be [$StructuredSerializeWithTransfer$](|message|, |transfer|). Rethrow any exceptions.
 
-    1. Run the steps to [=accept a message posted to the host=] for the [=host=] associated with the [=context object=]
+    1. Run the steps to [=accept a message posted to the host=] for the [=host=] associated with [=this=]
         with |serializeWithTransferResult|, |browsingContext|, |origin| and |targetOrigin|.
   </section>
 
@@ -615,12 +615,12 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   <section algorithm="portalactivateevent-adoptpredecessor">
     The <dfn method for="PortalActivateEvent"><code>adoptPredecessor()</code></dfn> method *must* run these steps:
 
-    1. Let |predecessorBrowsingContext| be the [=context object=]'s [=PortalActivateEvent/predecessor browsing context=].
+    1. Let |predecessorBrowsingContext| be [=this=]'s [=PortalActivateEvent/predecessor browsing context=].
         If it has none, throw an "{{InvalidStateError}}" {{DOMException}}.
 
-    1. Clear the [=context object=]'s [=PortalActivateEvent/predecessor browsing context=].
+    1. Clear [=this=]'s [=PortalActivateEvent/predecessor browsing context=].
 
-    1. Let |successorWindow| be the [=context object=]'s [=PortalActivateEvent/successor window=].
+    1. Let |successorWindow| be the [=this=]'s [=PortalActivateEvent/successor window=].
 
     1. Run the steps to [=adopt the predecessor browsing context=] |predecessorBrowsingContext| in |successorWindow|, and return the result.
 
@@ -654,7 +654,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   <section algorithm="window-portalhost">
     The <dfn attribute for="Window">portalHost</dfn> attribute *must* run the following steps:
 
-    1. Let |windowProxy| be the [=context object=]'s {{WindowProxy}} object.
+    1. Let |windowProxy| be [=this=]'s {{WindowProxy}} object.
 
     1. If there is no [=browsing context=] with |windowProxy| as its {{WindowProxy}} object, then return null.
 

--- a/index.bs
+++ b/index.bs
@@ -620,7 +620,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 
     1. Clear [=this=]'s [=PortalActivateEvent/predecessor browsing context=].
 
-    1. Let |successorWindow| be the [=this=]'s [=PortalActivateEvent/successor window=].
+    1. Let |successorWindow| be [=this=]'s [=PortalActivateEvent/successor window=].
 
     1. Run the steps to [=adopt the predecessor browsing context=] |predecessorBrowsingContext| in |successorWindow|, and return the result.
 


### PR DESCRIPTION
Resolves #75.