### PR TITLE
Clarify no-portals-in-subframes note.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -479,9 +479,15 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   1. [=close a portal element|Close=] |element|.
 
   <div class="note">
-    Since <{portal}> elements can have only a [=guest browsing context=] while
-    their [=node document|document=] belongs to a [=top-level browsing
-    context=], it is impossible to embed a [=portal browsing context=] in a
+    In particular, this means a <{portal}> element loses its [=guest browsing
+    context=] if it is moved to the [=active document=] of a [=nested browsing
+    context=].
+
+    Similarly, the steps when a <{portal}> element [=becomes browsing-context
+    connected=] prevent elements from creating a new [=guest browsing context=]
+    while inside such documents.
+
+    It is therefore impossible to embed a [=portal browsing context=] in a
     [=nested browsing context=].
   </div>
 


### PR DESCRIPTION
Hopefully this explains how the adopting steps prevent you from embedding a portal inside an <iframe>.

Resolves #82.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/portals/pull/103.html" title="Last updated on Apr 25, 2019, 3:21 PM UTC (ca61ba4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/103/9766d82...jeremyroman:ca61ba4.html" title="Last updated on Apr 25, 2019, 3:21 PM UTC (ca61ba4)">Diff</a>