### PR TITLE
Fixing bugs (README.md and protals-controller.js)

### DIFF
--- a/demos/portal-embed-demo/README.md
+++ b/demos/portal-embed-demo/README.md
@@ -117,7 +117,6 @@ window.addEventListener('portalactivate', evt => {
 // The activate function returns a Promise.
 // When the promise resolves, it means that the portal has been activated.
 // If this document was adopted by it, then window.portalHost will exist.
-// When the promise resolves, it means the page was adopted as a predecessor
 portal.activate().then(_ => {
   // Check if this document was adopted into a portal element.
   if (window.portalHost) {

--- a/demos/portal-embed-demo/public/js/portalog/portals-controller.js
+++ b/demos/portal-embed-demo/public/js/portalog/portals-controller.js
@@ -237,7 +237,7 @@ if ('HTMLPortalElement' in window) {
         location.href = embedURL;
     });
     iframe.src = embedURL;
-    embedContainer.appendChild(iframe, link);
+    embedContainer.append(iframe, link);
     // show fallback message
     document.querySelector('#fallback-message').style.display = "block";
 


### PR DESCRIPTION
Fixing bugs
- Removing "When the promise resolves, it means the page was adopted as a predecessor" comment from README.md (degradation)
- Changing using `append` from `appendChild` for adding fallback elements when the browser does not support Portals. The current implementation is using `appendChild` with multiple nodes as a parameter but it should be `append` in order to do that.
   - Checked other places using `appendChild` to see similar bugs. This one was the only one.