### PR TITLE
Fix ordering to permit postMessage immediately after adoptPredecessor.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -657,7 +657,7 @@ spec:url; type:dfn; for:/; text:url
 
     1. [=Queue a task=] to [=complete portal activation=].
 
-        Note: Queuing this immediately makes it possible to send messages to the
+        Note: Queuing this immediately makes it possible to send messages to the adopted
         portal during dispatch of the {{Window/portalactivate!!event}} event without
         ordering issues between the task to complete portal activation and the task
         to deliver the message.

--- a/index.bs
+++ b/index.bs
@@ -151,7 +151,10 @@ spec:url; type:dfn; for:/; text:url
         1. If |predecessorBrowsingContext| is not a [=portal browsing context=], [=close a browsing context|close=] it.
             The user agent *should not* [=refuse to allow the document to be unloaded=].
 
-        1. [=Queue a task=] to [=complete portal activation=].
+        1. If |event|'s [=PortalActivateEvent/predecessor browsing context=] is not null, then
+            [=queue a task=] to [=complete portal activation=].
+
+            Note: This happens only if the predecessor was not adopted by this point.
 
   </section>
 
@@ -651,6 +654,13 @@ spec:url; type:dfn; for:/; text:url
     1. Let |successorWindow| be [=this=]'s [=PortalActivateEvent/successor window=].
 
     1. Run the steps to [=adopt the predecessor browsing context=] |predecessorBrowsingContext| in |successorWindow|, and return the result.
+
+    1. [=Queue a task=] to [=complete portal activation=].
+
+        Note: Queuing this immediately makes it possible to send messages to the
+        portal during dispatch of the {{Window/portalactivate!!event}} event without
+        ordering issues between the task to complete portal activation and the task
+        to deliver the message.
 
     <wpt>
       portals-adopt-predecessor.html


### PR DESCRIPTION
@a4sriniv PTAL


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/portals/pull/126.html" title="Last updated on May 16, 2019, 8:44 PM UTC (d3cd8de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/126/951367a...jeremyroman:d3cd8de.html" title="Last updated on May 16, 2019, 8:44 PM UTC (d3cd8de)">Diff</a>