### PR TITLE
Remove host abstraction

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -220,9 +220,9 @@ spec:url; type:dfn; text:scheme
     portals-rendering.html
   </wpt>
 
-  A <{portal}> element has a <dfn for="HTMLPortalElement">guest browsing context</dfn>, which is
-  the [=portal browsing context=] whose [=host element=] it is, or null if no such browsing context
-  exists.
+  A <{portal}> element |portalElement| has a <dfn for="HTMLPortalElement">guest
+  browsing context</dfn>, which is the [=portal browsing context=] whose [=host
+  element=] is |portalElement|, or null if no such browsing context exists.
 
   The <dfn element-attr for="portal">src</dfn> attribute gives the [=URL=] of a
   page that the [=guest browsing context=] is to contain. The attribute, if

--- a/index.bs
+++ b/index.bs
@@ -112,8 +112,8 @@ spec:url; type:dfn; for:/; text:url
 
   <section algorithm="portal-browsing-context-activate">
     To <dfn>activate a portal browsing context</dfn> |successorBrowsingContext| in
-    place of |predecessorBrowsingContext| with data |serializeWithTransferResult|,
-    run the following steps [=in parallel=]:
+    place of |predecessorBrowsingContext| with data |serializeWithTransferResult|
+    and promise |promise|, run the following steps [=in parallel=]:
 
     1. [=Assert=]: The [=portal state=] of |predecessorBrowsingContext| is "`none`".
 
@@ -150,10 +150,12 @@ spec:url; type:dfn; for:/; text:url
 
         1. [=Dispatch=] |event| to |successorWindow|.
 
+        1. [=Queue a task=] from the [=portal task source=] to the
+            [=event loop=] associated with |predecessorBrowsingContext| to
+            resolve |promise| with undefined.
+
         1. If |predecessorBrowsingContext| is not a [=portal browsing context=], [=close a browsing context|close=] it.
             The user agent *should not* [=refuse to allow the document to be unloaded=].
-
-        1. [=Queue a task=] to [=complete portal activation=].
 
   </section>
 
@@ -247,11 +249,6 @@ spec:url; type:dfn; for:/; text:url
       };
   </xmp>
 
-  The following tasks may be [=queue a task|queued=] by this standard. Unless otherwise specified, each
-  task *must* be queued from the [=portal task source=].
-
-  * <dfn>complete portal activation</dfn>
-
   The <dfn attribute for="HTMLPortalElement">src</dfn> IDL attribute must [=reflect=] the <{portal/src}> content attribute.
 
   <section algorithm="htmlportalelement-activate">
@@ -292,11 +289,8 @@ spec:url; type:dfn; for:/; text:url
     1. Let |promise| be a new [=promise=].
 
     1. Run the steps to [=activate a portal browsing context|activate=] |portalBrowsingContext|
-        in place of |predecessorBrowsingContext| with data |serializeWithTransferResult|.
-
-        To [=complete portal activation=], run these steps:
-
-        1. Resolve |promise| with undefined.
+        in place of |predecessorBrowsingContext| with data |serializeWithTransferResult| and
+        promise |promise|.
 
     1. Return |promise|.
 

--- a/index.bs
+++ b/index.bs
@@ -87,26 +87,30 @@ spec:url; type:dfn; for:/; text:url
     A top-level "`none`" context can become "`orphaned`" by [=activate a portal browsing context|activating=]
     another context. An "`orphaned`" context can be [=adopt the predecessor browsing context|adopted=] to
     become a "`portal`" context. A "`portal`" context can become a "`none`" context by being
-    [=activate a portal browsing context|activated=] by its [=host=].
+    [=activate a portal browsing context|activated=] by its [=host browsing context=].
 
     A browsing context can be [=close a browsing context|closed=] while in any of these states.
   </div>
 
   A <dfn>portal browsing context</dfn> is a [=browsing context=] whose [=portal state=] is "`portal`".
 
-  A portal browsing context has a <dfn>host</dfn> which is embeds its rendered output and
-  receives messages sent from the portal browsing context. This specification defines
-  {{HTMLPortalElement}}, which hosts a portal browsing context inside an HTML document.
+  The <dfn>host element</dfn> of a [=portal browsing context=] is a <{portal}>
+  element which embeds its rendered output and receives messages sent from the
+  portal browsing context.
+
+  The <dfn>host browsing context</dfn> of a [=portal browsing context=] is its
+  [=host element=]'s [=node document|document=]'s [=browsing context=].
+
   A host defines steps to <dfn>accept a message posted to the host</dfn>.
 
   <p class="note">
     This implies that every [=portal browsing context=] is a [=top-level browsing context=].
     It is expected that a Web browser will not present a tab or window to display a portal browsing
-    context, but rather that it will be presented only through a [=host=] element.
+    context, but rather that it will be presented only through a [=host element=].
   </p>
 
   The <dfn>portal task source</dfn> is a [=task source=] used for tasks related to the
-  portal lifecycle and communication between a [=portal browsing context=] and its [=host=].
+  portal lifecycle and communication between a [=portal browsing context=] and its [=host browsing context=].
 
   <section algorithm="portal-browsing-context-activate">
     To <dfn>activate a portal browsing context</dfn> |successorBrowsingContext| in
@@ -186,7 +190,8 @@ spec:url; type:dfn; for:/; text:url
 
         1. [=Assert=]: The [=portal state=] of |predecessorBrowsingContext| is "`orphaned`".
 
-        1. Set the [=portal state=] of |predecessorBrowsingContext| to "`portal`", and set the [=host=] of |predecessorBrowsingContext| to |portalElement|.
+        1. Set the [=portal state=] of |predecessorBrowsingContext| to "`portal`", and
+            set the [=host element=] of |predecessorBrowsingContext| to |portalElement|.
 
     1. Return |portalElement|.
   </section>
@@ -211,8 +216,9 @@ spec:url; type:dfn; for:/; text:url
     portals-rendering.html
   </wpt>
 
-  A <{portal}> element may have a <dfn for="HTMLPortalElement">guest browsing context</dfn>, which is a
-  [=portal browsing context=]. If so, the element is the [=host=] of its [=guest browsing context=].
+  A <{portal}> element has a <dfn for="HTMLPortalElement">guest browsing context</dfn>, which is
+  the [=portal browsing context=] whose [=host element=] it is, or null if no such browsing context
+  exists.
 
   The <dfn element-attr for="portal">src</dfn> attribute gives the [=URL=] of a
   page that the [=guest browsing context=] is to contain. The attribute, if
@@ -460,8 +466,8 @@ spec:url; type:dfn; for:/; text:url
 
   1. [=Create a new browsing context=] with noopener, and let |newBrowsingContext| be the result.
 
-  1. Set the [=portal state=] of |newBrowsingContext| to "`portal`", and set the [=host=] of
-      |newBrowsingContext| to |element|.
+  1. Set the [=portal state=] of |newBrowsingContext| to "`portal`", and set
+     the [=host element=] of |newBrowsingContext| to |element|.
 
   1. Set |element|'s [=guest browsing context=] to |newBrowsingContext|.
 
@@ -535,7 +541,7 @@ spec:url; type:dfn; for:/; text:url
   The <dfn>portal host object</dfn> of a {{Window}} is a {{PortalHost}}.
 
   <div class="note">
-    The [=portal host object=] can be used to communicate with the [=host=] of a [=portal browsing context=].
+    The [=portal host object=] can be used to communicate with the [=host browsing context=].
     Its operations throw if used while its context is not a [=portal browsing context=] (i.e. there is no host).
     It is not accessible via {{Window/portalHost|window.portalHost}} at such times.
   </div>

--- a/index.bs
+++ b/index.bs
@@ -101,8 +101,6 @@ spec:url; type:dfn; for:/; text:url
   The <dfn>host browsing context</dfn> of a [=portal browsing context=] is its
   [=host element=]'s [=node document|document=]'s [=browsing context=].
 
-  A host defines steps to <dfn>accept a message posted to the host</dfn>.
-
   <p class="note">
     This implies that every [=portal browsing context=] is a [=top-level browsing context=].
     It is expected that a Web browser will not present a tab or window to display a portal browsing
@@ -370,42 +368,6 @@ spec:url; type:dfn; for:/; text:url
     </wpt>
   </section>
 
-  <section algorithm="htmlportalelement-acceptpostedmessage">
-    To [=accept a message posted to the host=] for a <{portal}> element |element| with
-    |serializeWithTransferResult|, |browsingContext|, |origin| and |targetOrigin|,
-    [=queue a task=] from the [=portal task source=] to the [=event loop=] associated with
-    the element's [=node document|document=]'s [=document browsing context|browsing context=]
-    to run the following steps:
-
-    1. If |browsingContext| is not the [=guest browsing context=] of |element|, then abort these steps.
-
-        Note: This might happen if this [=event loop=] had a queued task to deliver a message, but
-        it was not executed before the portal was [=activate a portal browsing context|activated=].
-        In such cases, the message is not delivered.
-
-    1. Let |settings| be the [=relevant settings object=] of |element|.
-
-    1. If |targetOrigin| is not a single literal U+002A ASTERISK character
-        (*) and |settings|'s [=environment settings object/origin=] is not
-        [=same origin=] with |targetOrigin|, then abort these steps.
-
-    1. Let |targetRealm| be |settings|'s [=environment settings object/realm=].
-
-    1. Let |deserializeRecord| be [$StructuredDeserializeWithTransfer$](|serializeWithTransferResult|, |targetRealm|).
-
-        If this throws an exception, catch it, [=fire an event=] named {{HTMLPortalElement/messageerror!!event}} at |element| using {{MessageEvent}}
-        with the {{MessageEvent/origin}} attribute initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |element|.
-
-    1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
-
-    1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in
-        |deserializeRecord|.\[[TransferredValues]], if any, maintaining their relative order.
-
-    1. [=Fire an event=] named {{HTMLPortalElement/message!!event}} at the |element| using {{MessageEvent}}, with the {{MessageEvent/origin}} attribute
-        initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |element|, the {{MessageEvent/data}} attribute
-        initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
-  </section>
-
   <section algorithm="htmlportalelement-close">
     To <dfn for="HTMLPortalElement">close a <{portal}> element</dfn> |element|, run the following steps:
 
@@ -587,8 +549,40 @@ spec:url; type:dfn; for:/; text:url
 
     1. Let |serializeWithTransferResult| be [$StructuredSerializeWithTransfer$](|message|, |transfer|). Rethrow any exceptions.
 
-    1. Run the steps to [=accept a message posted to the host=] for the [=host=] associated with [=this=]
-        with |serializeWithTransferResult|, |browsingContext|, |origin| and |targetOrigin|.
+    1. Let |hostElement| be the [=host element=] of |browsingContext|.
+
+    1. Let |hostBrowsingContext| be the [=host browsing context=] of |browsingContext|.
+
+    1. [=Queue a task=] from the [=portal task source=] to the [=event loop=]
+        associated with |hostBrowsingContext| to run the following steps:
+
+        1. If |browsingContext| is not the [=guest browsing context=] of |hostElement|, then abort these steps.
+
+            Note: This might happen if this [=event loop=] had a queued task to deliver a message, but
+            it was not executed before the portal was [=activate a portal browsing context|activated=].
+            In such cases, the message is not delivered.
+
+        1. Let |targetSettings| be the [=relevant settings object=] of |hostElement|.
+
+        1. If |targetOrigin| is not a single literal U+002A ASTERISK character
+            (*) and |targetSettings|'s [=environment settings object/origin=]
+            is not [=same origin=] with |targetOrigin|, then abort these steps.
+
+        1. Let |targetRealm| be |targetSettings|'s [=environment settings object/realm=].
+
+        1. Let |deserializeRecord| be [$StructuredDeserializeWithTransfer$](|serializeWithTransferResult|, |targetRealm|).
+
+            If this throws an exception, catch it, [=fire an event=] named {{HTMLPortalElement/messageerror!!event}} at |element| using {{MessageEvent}}
+            with the {{MessageEvent/origin}} attribute initialized to |origin| and the {{MessageEvent/source}} attribute initialized to |element|.
+
+        1. Let |messageClone| be |deserializeRecord|.\[[Deserialized]].
+
+        1. Let |newPorts| be a new [=frozen array type|frozen array=] consisting of all {{MessagePort}} objects in
+            |deserializeRecord|.\[[TransferredValues]], if any, maintaining their relative order.
+
+        1. [=Fire an event=] named {{HTMLPortalElement/message!!event}} at the |element| using {{MessageEvent}}, with the {{MessageEvent/origin}} attribute
+            initialized to |origin|, the {{MessageEvent/source}} attribute initialized to |element|, the {{MessageEvent/data}} attribute
+            initialized to |messageClone|, and the {{MessageEvent/ports}} attribute initialized to |newPorts|.
   </section>
 
   The following events are dispatched on {{PortalHost}} objects:


### PR DESCRIPTION
Resolves #87 by simply assuming that the only type of host is `HTMLPortalElement`. In particular this allows `PortalHost/postMessage` to be one contiguous block.

We can unwind this if we ever do care about some other kind of host environment.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/portals/pull/127.html" title="Last updated on May 17, 2019, 8:19 PM UTC (e77e9ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/127/665046f...jeremyroman:e77e9ea.html" title="Last updated on May 17, 2019, 8:19 PM UTC (e77e9ea)">Diff</a>