### PR TITLE
Only allow setting src on a portal to an HTTP(S) URL.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -53,6 +53,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
 </pre>
 <pre class="link-defaults">
 spec:url; type:dfn; for:/; text:url
+spec:url; type:dfn; text:scheme
 </pre>
 
 <section class="non-normative">
@@ -420,6 +421,8 @@ spec:url; type:dfn; for:/; text:url
     1. [=Parse a URL|Parse=] the value of the <{portal/src}> attribute. If that is not successful,
         then [=close a portal element|close=] |element| and abort these steps.
         Otherwise, let |url| be the [=resulting URL record=].
+
+    1. If the [=scheme=] of |url| is not an [=HTTP(S) scheme=], then abort these steps.
 
     1. Let |resource| be a new [=request=] whose [=request URL|URL=] is |url| and whose [=request referrer policy|referrer policy=] is "{{no-referrer}}".
 


### PR DESCRIPTION
Resolves #128.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/portals/pull/129.html" title="Last updated on May 16, 2019, 8:33 PM UTC (f85ac56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/129/951367a...jeremyroman:f85ac56.html" title="Last updated on May 16, 2019, 8:33 PM UTC (f85ac56)">Diff</a>