### PR TITLE
Use the new 'create a new top-level browsing context' abstraction.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -24,7 +24,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     type: dfn
         urlPrefix: browsers.html
             text: browsing context; url: browsing-context
-            text: create a new browsing context; url: creating-a-new-browsing-context
+            text: create a new top-level browsing context; url: creating-a-new-top-level-browsing-context
             text: document browsing context; url: concept-document-bc
             text: unit of related browsing contexts; url: unit-of-related-browsing-contexts
         urlPrefix: browsing-the-web.html
@@ -464,7 +464,7 @@ spec:url; type:dfn; text:scheme
         supported.
       </p>
 
-  1. [=Create a new browsing context=] with noopener, and let |newBrowsingContext| be the result.
+  1. Let |newBrowsingContext| be the result of [=create a new top-level browsing context|creating a new top-level browsing context=].
 
   1. Set the [=portal state=] of |newBrowsingContext| to "`portal`", and set the [=host=] of
       |newBrowsingContext| to |element|.


### PR DESCRIPTION
Resolves #81. There's more to do as far as updating things to use new things like agents and browsing context groups pervasively, but this is a fairly simple targeted fix.

@domenic?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/portals/pull/130.html" title="Last updated on May 16, 2019, 9:24 PM UTC (fc5bb68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/130/665046f...jeremyroman:fc5bb68.html" title="Last updated on May 16, 2019, 9:24 PM UTC (fc5bb68)">Diff</a>