### PR TITLE
Remove note that repeats that portal browsing contexts are top-level.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -103,12 +103,6 @@ spec:url; type:dfn; text:scheme
   The <dfn>host browsing context</dfn> of a [=portal browsing context=] is its
   [=host element=]'s [=node document|document=]'s [=browsing context=].
 
-  <p class="note">
-    This implies that every [=portal browsing context=] is a [=top-level browsing context=].
-    It is expected that a Web browser will not present a tab or window to display a portal browsing
-    context, but rather that it will be presented only through a [=host element=].
-  </p>
-
   The <dfn>portal task source</dfn> is a [=task source=] used for tasks related to the
   portal lifecycle and communication between a [=portal browsing context=] and its [=host browsing context=].
 


### PR DESCRIPTION
Resolves #63.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/portals/pull/135.html" title="Last updated on May 24, 2019, 6:31 PM UTC (e702e87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/135/d297d7d...jeremyroman:e702e87.html" title="Last updated on May 24, 2019, 6:31 PM UTC (e702e87)">Diff</a>