### PR TITLE
Replace the term 'unit of related browsing contexts', which is deprecated.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -24,9 +24,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     type: dfn
         urlPrefix: browsers.html
             text: browsing context; url: browsing-context
+            text: browsing context group; url: browsing-context-group
             text: create a new top-level browsing context; url: creating-a-new-top-level-browsing-context
             text: document browsing context; url: concept-document-bc
-            text: unit of related browsing contexts; url: unit-of-related-browsing-contexts
         urlPrefix: browsing-the-web.html
             text: prompt to unload; url: prompt-to-unload-a-document
         urlPrefix: history.html
@@ -45,6 +45,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
             text: discard a browsing context; url: a-browsing-context-is-discarded
 spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
     type: dfn
+        text: agent; url: sec-agents
         text: promise; url: sec-promise-objects
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
     type: dfn
@@ -242,10 +243,12 @@ spec:url; type:dfn; text:scheme
   present, must be a [=valid non-empty URL potentially surrounded by spaces=].
 
   <p class="note">
-    A <{portal}> is similar to an <{iframe}>, in that it allows another browsing context to be embedded.
-    However, the [=portal browsing context=] hosted by a <{portal}> is part of a separate [=unit of related
-    browsing contexts=]. The user agent is thus free to use a separate [=event loop=] for the browsing
-    contexts, even if they are [=same origin-domain=].
+    A <{portal}> is similar to an <{iframe}>, in that it allows another
+    browsing context to be embedded.  However, the [=portal browsing context=]
+    hosted by a <{portal}> is part of a separate [=browsing context group=],
+    and thus a separate [=agent=].  The user agent is therefore free to use a
+    separate [=event loop=] for the browsing contexts, even if they are [=same
+    origin-domain=].
   </p>
 
   <xmp class="idl">


### PR DESCRIPTION
Resolves #140.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/portals/pull/141.html" title="Last updated on May 30, 2019, 8:57 PM UTC (4e24cd6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/141/8070b25...jeremyroman:4e24cd6.html" title="Last updated on May 30, 2019, 8:57 PM UTC (4e24cd6)">Diff</a>