### PR TITLE
Fix references to HTML spec that should have been definition autolinks.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -392,7 +392,7 @@ spec:url; type:dfn; text:scheme
     1. Let |targetOrigin| be |options|["{{WindowPostMessageOptions|targetOrigin}}"].
 
     1. If |targetOrigin| is a single U+002F SOLIDUS character (/), then set |targetOrigin| to the
-        [[HTML#concept-settings-object-origin|origin]] of |settings|.
+        [=environment settings object/origin=] of |settings|.
 
     1. Otherwise, if |targetOrigin| is not a single U+002A ASTERISK character (*), then:
 
@@ -657,7 +657,7 @@ spec:url; type:dfn; text:scheme
     1. Let |targetOrigin| be |options|["{{WindowPostMessageOptions|targetOrigin}}"].
 
     1. If |targetOrigin| is a single U+002F SOLIDUS character (/), then set |targetOrigin| to the
-        [[HTML#concept-settings-object-origin|origin]] of |settings|.
+        [=environment settings object/origin=] of |settings|.
 
     1. Otherwise, if |targetOrigin| is not a single U+002A ASTERISK character (*), then:
 


### PR DESCRIPTION
Fixes #170.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/portals/pull/171.html" title="Last updated on Jan 15, 2020, 7:42 PM UTC (bbc382a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/171/9fdc1de...jeremyroman:bbc382a.html" title="Last updated on Jan 15, 2020, 7:42 PM UTC (bbc382a)">Diff</a>