### PR TITLE
Tweak PortalActivateOptions IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -333,9 +333,8 @@ spec:url; type:dfn; text:scheme
           attribute EventHandler onmessageerror;
       };
 
-      dictionary PortalActivateOptions {
-          any data = null;
-          sequence<object> transfer = [];
+      dictionary PortalActivateOptions : PostMessageOptions {
+          any data;
       };
   </xmp>
 
@@ -367,7 +366,7 @@ spec:url; type:dfn; text:scheme
 
     1. Let |serializeWithTransferResult| be
         [$StructuredSerializeWithTransfer$](|options|["{{PortalActivateOptions/data}}"],
-        |options|["{{PortalActivateOptions/transfer}}"]).
+        |options|["{{PostMessageOptions/transfer}}"]).
         Rethrow any exceptions.
 
     1. Let |promise| be a new [=promise=].


### PR DESCRIPTION
The normative change here is that by default data is undefined instead of null. Closes #74.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/portals/pull/204.html" title="Last updated on May 20, 2020, 8:52 PM UTC (cbfeef7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/204/7200658...cbfeef7.html" title="Last updated on May 20, 2020, 8:52 PM UTC (cbfeef7)">Diff</a>