### PR TITLE
Fire the load event for portals

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -38,6 +38,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
             text: becomes browsing-context disconnected; url: becomes-browsing-context-disconnected
         urlPrefix: origin.html
             text: origin; url: concept-origin
+        urlPrefix: parsing.html
+            text: completely loaded; url: completely-loaded
         urlPrefix: urls-and-fetching.html
             text: parse a URL; url: parse-a-url
             text: resulting URL record; url: resulting-url-record
@@ -607,6 +609,19 @@ spec:url; type:dfn; text:scheme
     It is therefore impossible to embed a [=portal browsing context=] in a
     [=nested browsing context=].
   </div>
+
+  Whenever a {{Document}} object |document| whose [=Document/browsing context=] is a
+  [=portal browsing context=] is marked as [=completely loaded=], run the following steps as part of
+  the queued task:
+
+  1. Let |element| be |document|'s [=Document/browsing context=]'s [=host element=].
+
+  1. [=Fire an event=] named {{HTMLElement/load!!event}} at |element|.
+
+  <wpt>
+    portal-onload-event.html
+    portals-cross-origin-load.sub.html
+  </wpt>
 
   The following events are dispatched on {{HTMLPortalElement}} objects:
 


### PR DESCRIPTION
Part of #26. This does not yet take care of delaying the load event of the outer window.

Some things to note:

- Iframes have an "iframe load in progress" flag which is [set before and unset after firing the event](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#iframe-load-event-steps). I guess this is to prevent a sort of infinite recursion? This didn't seem very necessary so I didn't copy it, but I might be wrong.

- Iframes have a "mute iframe load" flag which is set by document.open(), and has some known spec bugs. This seems like legacy so we shouldn't copy it, I'm pretty sure.

Please let me know what you think of these points, as well as how well this matches the Chromium implementation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/portals/pull/206.html" title="Last updated on May 20, 2020, 10:00 PM UTC (481268c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/206/f62ead1...481268c.html" title="Last updated on May 20, 2020, 10:00 PM UTC (481268c)">Diff</a>