### PR TITLE
Specify window.close() to no-op in unactivated portals

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -950,6 +950,24 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
       </tr>
     </tbody>
   </table>
+
+  APIs for creating and navigating browsing contexts by name {#patch-window-apis}
+  -------------------------------------------------------------------------------
+
+  Modify the definition of <a spec=HTML>script-closable</a> to prevent portals from closing
+  themselves pre-activation:
+
+  A [=browsing context=] is <dfn noexport>script-closable</dfn> if either of the following is true:
+
+  * it is an [=auxiliary browsing context=] that was created by script (as opposed to by an action
+    of the user); or
+  * it is a [=top-level browsing context=] <ins>whose [=portal state=] is "`none`"</ins> and whose
+    [=session history=] contains only one {{Document}}.
+
+  <wpt>
+    portals-close-window.html
+  </wpt>
+
 </section>
 
 <section>
@@ -1082,7 +1100,6 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
     portals-activate-empty-browsing-context.html
     portals-activate-network-error.html
     portals-activate-while-unloading.html
-    portals-close-window.html
     portals-focus.sub.html
     portals-navigate-after-adoption.html
     portals-repeated-activate.html

--- a/index.bs
+++ b/index.bs
@@ -954,8 +954,8 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
   APIs for creating and navigating browsing contexts by name {#patch-window-apis}
   -------------------------------------------------------------------------------
 
-  Modify the definition of <a spec=HTML>script-closable</a> to prevent portals from closing
-  themselves pre-activation:
+  Modify the definition of <a spec=HTML>script-closable</a> to prevent window closing while in a
+  [=portal browsing context=]:
 
   A [=browsing context=] is <dfn noexport>script-closable</dfn> if either of the following is true:
 


### PR DESCRIPTION
Closes #243.

Note: this specifies that portals in the state "orphaned" are also not closable. I don't believe we have tests for that, but we should, IMO.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/portals/pull/246.html" title="Last updated on Aug 26, 2020, 6:17 PM UTC (49a8aef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/246/863124f...49a8aef.html" title="Last updated on Aug 26, 2020, 6:17 PM UTC (49a8aef)">Diff</a>