### PR TITLE
Prevent navigations to non-HTTP(S) URLs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -29,6 +29,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         urlPrefix: browsing-the-web.html
             text: prompt to unload; url: prompt-to-unload-a-document
             text: reserved environment; for: navigation params; url: navigation-params-reserved-environment
+            text: request; for: navigation params; url: navigation-params-request
         urlPrefix: common-dom-interfaces.html
             text: limited to only known values; url: limited-to-only-known-values
             text: reflect; url: reflect
@@ -982,7 +983,9 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
     1. If |browsingContext|'s [=portal state=] is not "`none`", and any of the following hold:
 
           * |failure| is true;
-          * |response|'s [=response/url=] is null;
+          * |navigationParams|'s [=navigation params/request=] is null;
+          * |navigationParams|'s [=navigation params/request=]'s [=request/current URL=]'s
+            [=url/scheme=] is not a [=HTTP(S) scheme=];
           * |response| has a \``Content-Disposition`\` header specifying the `attachment`
               disposition type; or
           * |response|'s [=response/status=] is 204 or 205,
@@ -995,17 +998,6 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
             1. Run the [=environment discarding steps=] for <var ignore>navigationParam</var>'s
                 [=navigation params/reserved environment=].
         1. Return.
-
-        <p class="note">If |response| has a non-null [=response/url=], then by the time we reach <a
-        spec=HTML>process a navigate response</a>, that URL's [=url/scheme=] will always be a
-        [=HTTP(S) scheme=]. <a spec=FETCH>Scheme fetch</a> translates all other request URL schemes
-        into null-[=response/url=] [=responses=]. And if a redirect causes a non-HTTP(S) response
-        URL, then earlier parts of the navigation algorithm will either translate them into a
-        (null-[=response/url=]) [=network error=], or call back into [=fetch=] (and thus <a
-        spec=FETCH>scheme fetch</a>).</p>
-
-        <p class="note">Attempts to navigate to `javascript:` URLs will reach this part of the spec,
-        with |response|'s [=response/url=] always being null.</p>
   </div>
 
   <div algorithm="process a navigate URL scheme patch">

--- a/index.bs
+++ b/index.bs
@@ -28,6 +28,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
             text: create a new top-level browsing context; url: creating-a-new-top-level-browsing-context
         urlPrefix: browsing-the-web.html
             text: prompt to unload; url: prompt-to-unload-a-document
+            text: reserved environment; for: navigation params; url: navigation-params-reserved-environment
         urlPrefix: common-dom-interfaces.html
             text: limited to only known values; url: limited-to-only-known-values
             text: reflect; url: reflect
@@ -540,14 +541,15 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
     1. [=Navigate=] |guestBrowsingContext| to |resource|.
 
     <div class="note">
-      Unlike an <{iframe}> element, a <{portal}> element supports a state where
-      it has no associated browsing context. This is the initial state of a
-      <{portal}> element (i.e., it has no initial `about:blank` document;
-      instead it navigates directly to the first parsable URL assigned to it).
+      Unlike an <{iframe}> element, a <{portal}> element supports a state where it has no associated
+      browsing context. This is the initial state of a <{portal}> element. That is, the [=portal
+      browsing context=] has no web-developer-visible initial `about:blank` {{Document}}; instead it
+      [=navigates=] directly to the first parsable URL assigned to it, and if the navigation cannot
+      finish successfully, it [=close a browsing context|closes=] the browsing context before the
+      navigation algorithm finishes.
 
-      Similarly, a <{portal}> element responds to an unparsable <{portal/src}>
-      URL by [=close a browsing context|closing=] its browsing context, rather
-      than by navigating to `about:blank`.
+      Similarly, a <{portal}> element responds to an unparsable <{portal/src}> URL by [=close a
+      browsing context|closing=] its browsing context, rather than by navigating to `about:blank`.
     </div>
   </section>
 
@@ -970,6 +972,69 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
   <wpt>
     portals-close-window.html
   </wpt>
+
+  Navigation {#patch-navigation}
+  ------------------------------
+
+  Patch the <a spec=HTML>navigate</a> algorithm to prevent certain navigations in a
+  portal as follows:
+
+  <div algorithm="navigate patch">
+    In <a spec=HTML>navigate</a>, in the case where <var ignore>resource</var> is a [=request=]
+    whose [=request/url=]'s [=url/scheme=] is "`javascript`", prepend the following step as the
+    first step of the queued task:
+
+    1. If |browsingContext|'s [=portal state=] is not "`none`", then [=close a portal
+        element|close=] |browsingContext|'s [=host element=] and abort these steps.
+  </div>
+
+  <div algorithm="process a navigate response patch">
+    In <a spec=HTML>process a navigate response</a>, append the following after the step which
+    establishes the value of |failure|, but before the step which uses it to display an error page:
+
+    1. If |browsingContext|'s [=portal state=] is not "`none`", and any of the following hold:
+
+          * |failure| is true;
+          * |response|'s [=response/url=] is null;
+          * |response| has a \``Content-Disposition`\` header specifying the `attachment`
+              disposition type; or
+          * |response|'s [=response/status=] is 204 or 205,
+
+        then:
+
+        1. If |browsingContext|'s only entry in its [=session history=] is the initial `about:blank`
+            {{Document}}, then:
+            1. [=Close a portal element|Close=] |browsingContext|'s [=host element=].
+            1. Run the [=environment discarding steps=] for <var ignore>navigationParam</var>'s
+                [=navigation params/reserved environment=].
+            1. Return.
+        1. Otherwise, return.
+
+        <p class="note">If |response| has a non-null [=response/url=], then that URL's
+        [=url/scheme=] will always be a [=HTTP(S) scheme=].</p>
+  </div>
+
+  <div algorithm="process a navigate URL scheme patch">
+    In <a spec=HTML>process a navigate URL scheme</a>, insert the following step before the step
+    which displays inline content:
+
+    1. Otherwise, if |browsingContext|'s [=portal state=] is not "`none`", then [=close a portal
+        element|close=] |browsingContext|'s [=host element=].
+  </div>
+
+  Downloading resources {#patch-downloading}
+  ------------------------------------------
+
+  Modify the <a spec=HTML>allowed to download</a> algorithm to ensure that portaled content never
+  performs downloads, by prepending the following steps:
+
+  <div algorithm="allowed to download patch">
+    1. If <var ignore>initiator browsing context</var>'s [=portal state=] is not "`none`", then
+        return false.
+
+    1. If <var ignore>instantiator browsing context</var>'s [=portal state=] is not "`none`", then
+        return false.
+  </div>
 
 </section>
 

--- a/index.bs
+++ b/index.bs
@@ -1005,8 +1005,13 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
                 [=navigation params/reserved environment=].
         1. Return.
 
-        <p class="note">If |response| has a non-null [=response/url=], then that URL's
-        [=url/scheme=] will always be a [=HTTP(S) scheme=].</p>
+        <p class="note">If |response| has a non-null [=response/url=], then by the time we reach <a
+        spec=HTML>process a navigate response</a>, that URL's [=url/scheme=] will always be a
+        [=HTTP(S) scheme=]. <a spec=FETCH>Scheme fetch</a> translates all other request URL schemes
+        into null-[=response/url=] [=responses=]. And if a redirect causes a non-HTTP(S) response
+        URL, then earlier parts of the navigation algorithm will either translate them into a
+        (null-[=response/url=]) [=network error=], or call back into [=fetch=] (and thus <a
+        spec=FETCH>scheme fetch</a>).</p>
   </div>
 
   <div algorithm="process a navigate URL scheme patch">

--- a/index.bs
+++ b/index.bs
@@ -975,15 +975,6 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
   Patch the <a spec=HTML>navigate</a> algorithm to prevent certain navigations in a
   portal as follows:
 
-  <div algorithm="navigate patch">
-    In <a spec=HTML>navigate</a>, in the case where <var ignore>resource</var> is a [=request=]
-    whose [=request/url=]'s [=url/scheme=] is "`javascript`", prepend the following step as the
-    first step of the queued task:
-
-    1. If |browsingContext|'s [=portal state=] is not "`none`", then [=close a portal
-        element|close=] |browsingContext|'s [=host element=] and abort these steps.
-  </div>
-
   <div algorithm="process a navigate response patch">
     In <a spec=HTML>process a navigate response</a>, append the following after the step which
     establishes the value of |failure|, but before the step which uses it to display an error page:
@@ -1012,6 +1003,9 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
         URL, then earlier parts of the navigation algorithm will either translate them into a
         (null-[=response/url=]) [=network error=], or call back into [=fetch=] (and thus <a
         spec=FETCH>scheme fetch</a>).</p>
+
+        <p class="note">Attempts to navigate to `javascript:` URLs will reach this part of the spec,
+        with |response|'s [=response/url=] always being null.</p>
   </div>
 
   <div algorithm="process a navigate URL scheme patch">

--- a/index.bs
+++ b/index.bs
@@ -1003,8 +1003,7 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
             1. [=Close a portal element|Close=] |browsingContext|'s [=host element=].
             1. Run the [=environment discarding steps=] for <var ignore>navigationParam</var>'s
                 [=navigation params/reserved environment=].
-            1. Return.
-        1. Otherwise, return.
+        1. Return.
 
         <p class="note">If |response| has a non-null [=response/url=], then that URL's
         [=url/scheme=] will always be a [=HTTP(S) scheme=].</p>

--- a/index.bs
+++ b/index.bs
@@ -519,9 +519,6 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
 
         Otherwise, let |url| be the [=resulting URL record=].
 
-    1. If the [=url/scheme=] of |url| is not an [=HTTP(S) scheme=], then [=close a portal element|close=]
-        |element| and return.
-
     1. If |element|'s [=HTMLPortalElement/guest browsing context=] is null, then run the following steps:
 
         1. Let |newBrowsingContext| be the result of
@@ -554,7 +551,6 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
   </section>
 
   <wpt>
-    portal-non-http-navigation.html
     portals-cross-origin-load.sub.html
     portals-referrer.html
     portals-referrer-inherit-header.html
@@ -1021,6 +1017,10 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
     1. Otherwise, if |browsingContext|'s [=portal state=] is not "`none`", then [=close a portal
         element|close=] |browsingContext|'s [=host element=].
   </div>
+
+  <wpt>
+    portal-non-http-navigation.html
+  </wpt>
 
   Downloading resources {#patch-downloading}
   ------------------------------------------


### PR DESCRIPTION
Closes #145.

Test cases this should generate:


- For each `badURL` of `data:text/html,foo`, `javascript:'a string'`, `javascript:undefined`, `about:blank`, a `blob:` URL, and a real URL that is served with the `Content-Disposition: attachment` header, a real URL that has a 204 response, and a real URL that has a 205 response:

   - `<portal src="badURL"></portal>` must end up closed
   
   - `<portal src="redirect"></portal>` where `redirect` redirects (say, 302) to `badURL` must end up closed

   - `<portal src="web+test:foo"></portal>` where `web+test` is mapped using `registerProtocolHandler` to `badURL` must end up closed. (Only possible for same-origin HTTPS bad URLs; you can't register the others.)

   - `<portal src="test"></portal>` where `test` does `location.href = badURL` must stay on `test` and not end up closed
   
   - `<portal src="test"></portal>` where `test` contains `<meta http-equiv="refresh" content="0; URL=badURL">` must stay on `test` and not end up closed

   - `<portal src="test"></portal>` where `test` contains `<a href="badURL">a</a><script>document.querySelector("a").click()` must stay on `test` and not end up closed
   
- `<portal src="404"></portal>` must show the 404 page from the server, and not end up closed

- `<portal src="500"></portal>` must show the 500 page from the server, and not end up closed

- `registerProtocolHandler("web+soup", "soup?url=%s")` + `<portal src="web+soup:chicken-kïwi"></portal>` should load, and not end up closed, despite the non-HTTP(S) `src=""`.

- `<portal src="unresolvable"></portal>` must end up closed


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/portals/pull/247.html" title="Last updated on Sep 21, 2020, 4:01 PM UTC (bde9605)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/247/777e565...bde9605.html" title="Last updated on Sep 21, 2020, 4:01 PM UTC (bde9605)">Diff</a>