### PR TITLE
Delay activation on initial loading; src="" changes reset portal BC

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -131,6 +131,22 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
 
     1. [=Assert=]: The [=portal state=] of |predecessorBrowsingContext| is "`none`".
 
+    1. If |successorBrowsingContext|'s only entry in its [=session history=] is the initial
+        `about:blank` {{Document}}, then wait until either this is no longer true, or
+        |successorBrowsingContext|'s [=host element=] becomes null.
+
+        <p class="note">This means that the initial load is still happening in
+        |successorBrowsingContext|. We wait for it to complete, either successfully or
+        unsuccessfully, before continuing.</p>
+
+    1. If |successorBrowsingContext|'s [=host element=] is null, then:
+
+        1. [=Queue a global task=] on the [=portal task source=] given
+            |predecessorBrowsingContext|'s [=browsing context/active window=] to [=reject=]
+            |promise| with an "{{InvalidStateError}}" {{DOMException}}.
+
+        1. Return.
+
     1. Set the [=host element=] of |successorBrowsingContext| to null.
 
         User agents *should*, however, attempt to preserve the rendering of the
@@ -512,7 +528,7 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
 
     1. [=Assert=]: |hostBrowsingContext| is a [=top-level browsing context=].
 
-    1. [=close the portal element|Close=] |element|.
+    1. [=close a portal element|Close=] |element|.
 
     1. If |element| has no <{portal/src}> attribute specified, or its value is the empty string,
         then return.

--- a/index.bs
+++ b/index.bs
@@ -512,25 +512,23 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
 
     1. [=Assert=]: |hostBrowsingContext| is a [=top-level browsing context=].
 
+    1. [=close the portal element|Close=] |element|.
+
     1. If |element| has no <{portal/src}> attribute specified, or its value is the empty string,
-        then [=close a portal element|close=] |element| and return.
+        then return.
 
     1. [=Parse a URL|Parse=] the value of the <{portal/src}> attribute. If that is not successful,
-        then [=close a portal element|close=] |element| and return.
+        then return.
 
         Otherwise, let |url| be the [=resulting URL record=].
 
-    1. If |element|'s [=HTMLPortalElement/guest browsing context=] is null, then run the following steps:
+    1. Assert: |element|'s [=HTMLPortalElement/guest browsing context=] is null.
 
-        1. Let |newBrowsingContext| be the result of
-            [=create a new top-level browsing context|creating a new top-level browsing context=].
+    1. Let |guestBrowsingContext| be the result of
+        [=create a new top-level browsing context|creating a new top-level browsing context=].
 
-        1. Set the [=portal state=] of |newBrowsingContext| to "`portal`", and set
-            the [=host element=] of |newBrowsingContext| to |element|.
-
-    1. Let |guestBrowsingContext| be |element|'s [=HTMLPortalElement/guest browsing context=].
-
-    1. [=Assert=]: |guestBrowsingContext| is not null.
+    1. Set the [=portal state=] of |guestBrowsingContext| to "`portal`", and set the [=host element=]
+        of |guestBrowsingContext| to |element|.
 
     1. Let |resource| be a new [=request=] whose [=request/url=] is |url|
         and whose [=request/referrer policy=] is the current state of


### PR DESCRIPTION
Closes #197 by causing all changes to `src=""` to close the portal browsing context, and re-create it.

Closes #227 by causing `activate()` to delay promise resolution/rejection until the initial load in a new browsing context has finished.

<details>
<summary>Old content</summary>
@jakearchibald, @kjmcnee, please take a look. Other reviewers also appreciated.

Two main things to consider:

- Is this the behavior we want? I know @jakearchibald was skeptical about the "After the initial load" behavior, but I think it's better, and I believe @kjmcnee indicated that it's implementable. The alternative is to delay activation like we do with initial load, but that seems like a worse user experience.

- Is this explainer structure reasonable? I'm wondering if, e.g., we should move all discussion of activation failure from the bfcache section into here, or merge this with the bfcache section somehow. Also the flow feels a bit weird, in that we have to spend so much time up front explaining closed portals. But I couldn't find a better place to put it.
</details>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/portals/pull/253.html" title="Last updated on Sep 28, 2020, 8:46 PM UTC (9c244a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/253/703914f...9c244a8.html" title="Last updated on Sep 28, 2020, 8:46 PM UTC (9c244a8)">Diff</a>