### PR TITLE
Add advanced session history integration to explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,13 +247,13 @@ onrestoration | The previous contents were restored into this portal element.
 ondiscard | The portal contents have been discarded due to a need to reclaim resources or due to the inability to perform restoration.
 onfreeze/onresume | Indicates when the portal context has been [frozen/resumed](https://github.com/WICG/page-lifecycle).
 
-There is one more event, `window.onportaladopt`, needed to communicate to a page that it has become a portal when other forms (`activate` promise resolving or `onactivation` of a predecessor portal) are not applicable.
+There is one more event, `window.onportaladopt`, needed to communicate to a page that it has become a portal when other forms (`activate()` promise resolving or `onactivation` of a predecessor portal) are not applicable.
 
-Depending on the semantics of the page, the activation of a predecessor may be viewed as traversing session history. For example, if scrolling a preview portal into view activates the preview, then scrolling back up could be considered a back navigation. A page can specify how a portal activation should affect session history by setting the `history` field in the activation options to one of `push` (default), `replace`, `back`, `forward`.
+Depending on the semantics of the page, the activation of a predecessor may be viewed as traversing session history. For example, if scrolling a preview portal into view activates the preview, then scrolling back up could be considered a back navigation. A page can specify how a portal activation should affect session history by setting the `history` field in the activation options to one of `push` (default), `replace`, `back`, or `forward`.
 
 Consider how the [navigation transition example above](#navigation-transitions) may be extended to handle back button transitions.
 ```js
-portal.addEventListener(‘restoration’, async () => {
+portal.addEventListener('restoration', async () => {
   // Reverse the animation from the whole viewport preview.
   if (!matchMedia('(prefers-reduced-motion: reduce)').matches) {
     await portal.animate([{ width: '100px', height: '100px' }], { duration: 300 }).finished;
@@ -264,7 +264,7 @@ portal.addEventListener(‘restoration’, async () => {
     portal.style.height = '100px';
   }
 });
-portal.addEventListener(‘discard’, () => {
+portal.addEventListener('discard', () => {
   portal.hidden = true;
 });
 ```

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ portal.addEventListener('discard', async () => {
 });
 ```
 
-Now let's consider a more advanced example where a user goes back and forth between pages of a site. Suppose we have a page embedding a widget with a portal. When the user taps on it, it's activated so the user can interact with the widget. The widget page adopts the host page and displays it as a background to produce a lightbox style UI. Suppose the user then performs a back navigation followed by a forward navigation.\
+Now let's consider a more advanced example where a user goes back and forth between pages of a site. Suppose we have a page embedding a widget with a portal. When the user taps on it, it's activated so the user can interact with the widget. The widget page adopts the host page and displays it as a background to produce a lightbox style UI. Suppose the user then performs a back navigation followed by a forward navigation.
+
 Host page:
 ```js
 function createWidget() {
@@ -359,7 +360,8 @@ window.addEventListener('portalactivate', (e) => {
 });
 ```
 
-With this, the user can keep pressing back and forward which has the effect of dismissing and re-showing the widget. Suppose we now want to have the ability to dismiss the widget by tapping on the background of the widget. This can be done as follows:\
+With this, the user can keep pressing back and forward which has the effect of dismissing and re-showing the widget. Suppose we now want to have the ability to dismiss the widget by tapping on the background of the widget. This can be done as follows:
+
 Widget page:
 ```js
 // Continuing with |predecessor| in |portalactivate|:

--- a/README.md
+++ b/README.md
@@ -316,19 +316,22 @@ function createWidget() {
 
     // The host is adopted now, so make any desired visual changes for being
     // embedded.
+    document.body.classList.add('embedded');
   });
 
-  portal.addEventListener(‘restore’, () => {
+  portal.addEventListener('restore', async () => {
     // The user pressed back, so undo any visual changes done to the host while
     // it was adopted.
+    document.body.classList.remove('embedded');
     if (!matchMedia('(prefers-reduced-motion: reduce)').matches) {
       await portal.animate(/* ... */).finished;
     }
   });
-  portal.addEventListener(‘activate’, () => {
+  portal.addEventListener('activate', () => {
     // After the user returned from the widget page, they pressed forward. The
     // widget page is implicitly activated again.
     // Make any desired visual changes to the host page for being embedded.
+    document.body.classList.add('embedded');
   });
 }
 ```
@@ -338,14 +341,15 @@ Widget page:
 // whether we're in a portal so we can show an appropriate view.
 if (window.portalHost) {
   // Show embedded view.
-} else {
-  // Show full view.
+  document.body.classList.add('embedded');
 }
 
 window.addEventListener('portalactivate', (e) => {
   // Show full view.
+  document.body.classList.remove('embedded');
 
   // Augment the full view by showing the host in the background.
+  document.body.classList.add('showPredecessor');
   let predecessorContainer = document.getElementById('predecessorContainer');
   let predecessor = e.adoptPredecessor();
   // Note that the second time |portalactivate| is called (when the user presses
@@ -356,6 +360,8 @@ window.addEventListener('portalactivate', (e) => {
   predecessor.onactivate = () => {
     // The user pressed back to return to the host page.
     // Show embedded view.
+    document.body.classList.remove('showPredecessor');
+    document.body.classList.add('embedded');
   };
 });
 ```
@@ -371,6 +377,8 @@ predecessor.onclick = async (e) => {
   // specify that this activation traverses session history.
   await predecessor.activate({history: 'back'});
   // Show embedded view.
+  document.body.classList.remove('showPredecessor');
+  document.body.classList.add('embedded');
 };
 ```
 


### PR DESCRIPTION
We expand on how portals affect session history and how reverse
transitions may be performed in the presence of bfcache and portal
adoption.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/portals/pull/256.html" title="Last updated on Nov 2, 2020, 3:40 PM UTC (cf8c35b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/256/3c57d0d...cf8c35b.html" title="Last updated on Nov 2, 2020, 3:40 PM UTC (cf8c35b)">Diff</a>