### PR TITLE
Fix the use of [HTMLConstructor] extended attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -350,8 +350,10 @@ spec: ecma-262; urlPrefix: http://tc39.github.io/ecma262/
   </p>
 
   <xmp class="idl">
-      [Exposed=Window, HTMLConstructor]
+      [Exposed=Window]
       interface HTMLPortalElement : HTMLElement {
+          [HTMLConstructor] constructor();
+
           [CEReactions] attribute USVString src;
           [CEReactions] attribute DOMString referrerPolicy;
 


### PR DESCRIPTION
It "must only appear on constructor operations":
https://html.spec.whatwg.org/#htmlconstructor


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/portals/pull/265.html" title="Last updated on Apr 19, 2021, 9:40 AM UTC (18ef638)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/portals/265/0155437...foolip:18ef638.html" title="Last updated on Apr 19, 2021, 9:40 AM UTC (18ef638)">Diff</a>